### PR TITLE
Add expression call checker

### DIFF
--- a/Validator/Sources/AbstractClassValidatorFramework/Checkers/AbstractClassChecker.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Checkers/AbstractClassChecker.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SourceKittenFramework
+
+/// A encapsulation of a specific abstract class rule to be checked on
+/// an AST structure of a file.
+protocol AbstractClassChecker {
+
+    /// Check the given AST structure for any abstract rule violations.
+    ///
+    /// - parameter structure: The AST structure to check.
+    /// - parameter sourceUrl: The URL where the structure is parsed from.
+    /// - throws: If any violations of the rule is found.
+    func check(structure: Structure, fromSourceUrl sourceUrl: URL) throws
+}

--- a/Validator/Sources/AbstractClassValidatorFramework/Checkers/ExpressionCallChecker.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Checkers/ExpressionCallChecker.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SourceKittenFramework
+import SourceParsingFramework
+
+/// Checks the rule that abstract classes cannot be directly instantiated.
+class ExpressionCallChecker: AbstractClassChecker {
+
+    /// Initializer.
+    ///
+    /// - parameter abstractClassDefinitions: The definitions of abstract
+    /// classes to check for.
+    init(abstractClassDefinitions: [AbstractClassDefinition]) {
+        self.abstractClassDefinitions = abstractClassDefinitions
+    }
+
+    /// Check the given AST structure for any abstract rule violations.
+    ///
+    /// - parameter structure: The AST structure to check.
+    /// - parameter sourceUrl: The URL where the structure is parsed from.
+    /// - throws: If any violations of the rule is found.
+    func check(structure: Structure, fromSourceUrl sourceUrl: URL) throws {
+        guard !abstractClassDefinitions.isEmpty else {
+            return
+        }
+
+        let abstractClassNames = Set<String>(abstractClassDefinitions.map { (definition: AbstractClassDefinition) -> String in
+            definition.name
+        })
+
+        // Remove explicit `init` annotations.
+        let expressionCallTypes = structure.uniqueExpressionCallNames.compactMap { (call: String) -> String? in
+            if call.hasSuffix(".init") {
+                return call.components(separatedBy: ".").first
+            } else {
+                return call
+            }
+        }
+
+        for type in expressionCallTypes {
+            if abstractClassNames.contains(type) {
+                throw GenericError.withMessage("Abstract class \(type) should not be directly instantiated in file \(sourceUrl.path)")
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private let abstractClassDefinitions: [AbstractClassDefinition]
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallCheckerTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallCheckerTests.swift
@@ -1,0 +1,88 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SourceKittenFramework
+import SourceParsingFramework
+import XCTest
+@testable import AbstractClassValidatorFramework
+
+class ExpressionCallCheckerTests: BaseFrameworkTests {
+
+    private var abstractClassDefinition: AbstractClassDefinition!
+
+    override func setUp() {
+        super.setUp()
+
+        let abstractVarDefinition = AbstractVarDefinition(name: "abVar", returnType: "Var")
+        abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [])
+    }
+
+    func test_check_noUsage_verifyResult() {
+        let url = fixtureUrl(for: "NoAbstractClass.swift")
+        let file = File(contents: try! String(contentsOf: url))
+        let structure = try! Structure(file: file)
+
+        let checker = ExpressionCallChecker(abstractClassDefinitions: [abstractClassDefinition])
+        do {
+            try checker.check(structure: structure, fromSourceUrl: url)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func test_check_hasSubclassUsage_noViolations() {
+        let url = fixtureUrl(for: "UsageSubclass.swift")
+        let file = File(contents: try! String(contentsOf: url))
+        let structure = try! Structure(file: file)
+
+        let checker = ExpressionCallChecker(abstractClassDefinitions: [abstractClassDefinition])
+        do {
+            try checker.check(structure: structure, fromSourceUrl: url)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func test_check_hasTypeUsage_noViolations() {
+        let url = fixtureUrl(for: "UsageType.swift")
+        let file = File(contents: try! String(contentsOf: url))
+        let structure = try! Structure(file: file)
+
+        let checker = ExpressionCallChecker(abstractClassDefinitions: [abstractClassDefinition])
+        do {
+            try checker.check(structure: structure, fromSourceUrl: url)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func test_check_hasIViolations() {
+        let url = fixtureUrl(for: "ViolateInstantiation.swift")
+        let file = File(contents: try! String(contentsOf: url))
+        let structure = try! Structure(file: file)
+
+        let checker = ExpressionCallChecker(abstractClassDefinitions: [abstractClassDefinition])
+        do {
+            try checker.check(structure: structure, fromSourceUrl: url)
+            XCTFail()
+        } catch GenericError.withMessage(let message) {
+            XCTAssertTrue(message.contains(abstractClassDefinition.name))
+            XCTAssertTrue(message.contains(url.path))
+        } catch {
+            XCTFail()
+        }
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/ViolateInstantiation.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/ViolateInstantiation.swift
@@ -1,0 +1,9 @@
+class ViolationClass {
+    var someProperty: SomeAbstractC {
+        return SomeAbstractC(blah: Blah(), kaa: BB())
+    }
+
+    func someMethod() -> String {
+        return ""
+    }
+}


### PR DESCRIPTION
This checker ensures no expression calls are made directly using any of abstract class types.