### PR TITLE
Aggregate ancestor abstract properties and methods

### DIFF
--- a/Validator/Sources/AbstractClassValidatorFramework/Models/AbstractClassDefinition.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Models/AbstractClassDefinition.swift
@@ -20,17 +20,19 @@ import Foundation
 let abstractMethodType = "abstractMethod"
 
 /// A data model representing the definition of an abstract class.
-struct AbstractClassDefinition {
+struct AbstractClassDefinition: Equatable {
     /// The name of the abstract class.
     let name: String
     /// The abstract vars.
     let abstractVars: [AbstractVarDefinition]
     /// The abstract methods.
     let abstractMethods: [AbstractMethodDefinition]
+    /// The names of inherited types.
+    let inheritedTypes: [String]
 }
 
 /// A data model representing the definition of an abstract method.
-struct AbstractMethodDefinition {
+struct AbstractMethodDefinition: Equatable {
     /// The name of the abstract method.
     let name: String
     /// The return type of the abstract method.
@@ -44,7 +46,7 @@ struct AbstractMethodDefinition {
 
 /// A data model representing the definition of an abstract computed
 /// property.
-struct AbstractVarDefinition {
+struct AbstractVarDefinition: Equatable {
     /// The name of the abstract method.
     let name: String
     /// The return type of the abstract method.

--- a/Validator/Sources/AbstractClassValidatorFramework/Processors/AbstractClassDefinitionsAggregator.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Processors/AbstractClassDefinitionsAggregator.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/// A processing unit that aggregates abstract class definitions'
+/// abstract properties and methods with their ancestor abstract
+/// class definitions.
+class AbstractClassDefinitionsAggregator {
+
+    /// Aggregate the given abstract class definitions based their
+    /// class inheritance structures.
+    ///
+    /// - parameter abstractClassDefinitions: The definitions to
+    /// aggregate.
+    /// - returns: The aggregated abstract class definitions where
+    /// sub-abstract class definitions include abstract property and
+    /// method definitions of their inherited super-abstract classes.
+    func aggregate(abstractClassDefinitions: [AbstractClassDefinition]) -> [AbstractClassDefinition] {
+        // Create a map of name to definition for easy access.
+        var definitionsMap = [String: ParentedAbstractClassDefinition]()
+        for definition in abstractClassDefinitions {
+            definitionsMap[definition.name] = ParentedAbstractClassDefinition(value: definition)
+        }
+
+        // Link individual definitions to their ancestor definitions.
+        for (_, definition) in definitionsMap {
+            let ancestors = definition.value.inheritedTypes.compactMap { (parentName: String) -> ParentedAbstractClassDefinition? in
+                definitionsMap[parentName]
+            }
+            definition.ancestors.append(contentsOf: ancestors)
+        }
+
+        // Consolidate each definition with its ancestor definitions.
+        return Array(definitionsMap.values).map { (definition: ParentedAbstractClassDefinition) -> AbstractClassDefinition in
+            var allAbstractVars = definition.value.abstractVars
+            var allAbstractMethods = definition.value.abstractMethods
+            iterateAllAncestors(of: definition) { (ancestor: ParentedAbstractClassDefinition) in
+                allAbstractVars.append(contentsOf: ancestor.value.abstractVars)
+                allAbstractMethods.append(contentsOf: ancestor.value.abstractMethods)
+            }
+
+            return AbstractClassDefinition(name: definition.value.name, abstractVars: allAbstractVars, abstractMethods: allAbstractMethods, inheritedTypes: definition.value.inheritedTypes)
+        }
+    }
+
+    // MARK: - Private
+
+    private func iterateAllAncestors(of definition: ParentedAbstractClassDefinition, handler: (ParentedAbstractClassDefinition) -> ()) {
+        var ancestors = definition.ancestors
+        while !ancestors.isEmpty {
+            let ancestor = ancestors.removeFirst()
+            handler(ancestor)
+            ancestors.append(contentsOf: ancestor.ancestors)
+        }
+    }
+}
+
+private class ParentedAbstractClassDefinition {
+    fileprivate let value: AbstractClassDefinition
+    fileprivate var ancestors = [ParentedAbstractClassDefinition]()
+
+    init(value: AbstractClassDefinition) {
+        self.value = value
+    }
+}

--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/DeclarationProducerTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/DeclarationProducerTask.swift
@@ -46,7 +46,7 @@ class DeclarationProducerTask: AbstractTask<[AbstractClassDefinition]> {
                     let abstractVars = declaration.abstractVars
                     let abstractMethods = declaration.abstractMethods
                     if !abstractVars.isEmpty || !abstractMethods.isEmpty {
-                        return AbstractClassDefinition(name: declaration.name, abstractVars: abstractVars, abstractMethods: abstractMethods)
+                        return AbstractClassDefinition(name: declaration.name, abstractVars: abstractVars, abstractMethods: abstractMethods, inheritedTypes: declaration.inheritedTypes)
                     }
                 }
                 return nil

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/AbstractClassDefinitionsAggregatorTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/AbstractClassDefinitionsAggregatorTests.swift
@@ -1,0 +1,74 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AbstractClassValidatorFramework
+
+class AbstractClassDefinitionsAggregatorTests: BaseFrameworkTests {
+
+    func test_aggregate_withAncestors_verifyAggregatedResults() {
+        let grandParentVars = [AbstractVarDefinition(name: "gV", returnType: "GV")]
+        let grandParentMethods = [AbstractMethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: []), AbstractMethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"])]
+
+        let parentVars = [AbstractVarDefinition(name: "pV1", returnType: "PV1"), AbstractVarDefinition(name: "pV2", returnType: "PV2")]
+        let parentMethods = [AbstractMethodDefinition(name: "gM", returnType: "GM", parameterTypes: [])]
+
+        let childVars = [AbstractVarDefinition(name: "cV", returnType: "CV")]
+        let childMethods = [AbstractMethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"])]
+
+        let definitions = [
+            AbstractClassDefinition(name: "GrandParent", abstractVars: grandParentVars, abstractMethods: grandParentMethods, inheritedTypes: []),
+            AbstractClassDefinition(name: "Parent", abstractVars: parentVars, abstractMethods: parentMethods, inheritedTypes: ["GrandParent"]),
+            AbstractClassDefinition(name: "Child", abstractVars: childVars, abstractMethods: childMethods, inheritedTypes: ["Parent"]),
+        ]
+
+        let aggregator = AbstractClassDefinitionsAggregator()
+
+        let results = aggregator.aggregate(abstractClassDefinitions: definitions)
+
+        for definition in results {
+            switch definition.name {
+            case "Child":
+                let allVars = grandParentVars + parentVars + childVars
+                for v in allVars {
+                    XCTAssertTrue(definition.abstractVars.contains(v))
+                }
+                let allMethods = grandParentMethods + parentMethods + childMethods
+                for m in allMethods {
+                    XCTAssertTrue(definition.abstractMethods.contains(m))
+                }
+            case "Parent":
+                let allVars = grandParentVars + parentVars
+                for v in allVars {
+                    XCTAssertTrue(definition.abstractVars.contains(v))
+                }
+                let allMethods = grandParentMethods + parentMethods
+                for m in allMethods {
+                    XCTAssertTrue(definition.abstractMethods.contains(m))
+                }
+            case "GrandParent":
+                for v in grandParentVars {
+                    XCTAssertTrue(definition.abstractVars.contains(v))
+                }
+                for m in grandParentMethods {
+                    XCTAssertTrue(definition.abstractMethods.contains(m))
+                }
+            default:
+                XCTFail()
+            }
+        }
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallCheckerTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallCheckerTests.swift
@@ -27,7 +27,7 @@ class ExpressionCallCheckerTests: BaseFrameworkTests {
         super.setUp()
 
         let abstractVarDefinition = AbstractVarDefinition(name: "abVar", returnType: "Var")
-        abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [])
+        abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [], inheritedTypes: [])
     }
 
     func test_check_noUsage_verifyResult() {

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/UsageFilterTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/UsageFilterTaskTests.swift
@@ -25,7 +25,7 @@ class UsageFilterTaskTests: BaseFrameworkTests {
         super.setUp()
 
         let abstractVarDefinition = AbstractVarDefinition(name: "abVar", returnType: "Var")
-        abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [])
+        abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [], inheritedTypes: [])
     }
 
     func test_execute_noExclusion_noAbstractClass_verifyResult() {


### PR DESCRIPTION
Walk through the entire inheritance chain of an abstract class to aggregate all ancestors properties and methods.