### PR TITLE
Fix nested class declarations

### DIFF
--- a/Validator/Sources/AbstractClassValidatorFramework/Models/AbstractClassDefinition.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Models/AbstractClassDefinition.swift
@@ -24,31 +24,35 @@ struct AbstractClassDefinition: Equatable {
     /// The name of the abstract class.
     let name: String
     /// The abstract vars.
-    let abstractVars: [AbstractVarDefinition]
+    let abstractVars: [VarDefinition]
     /// The abstract methods.
-    let abstractMethods: [AbstractMethodDefinition]
+    let abstractMethods: [MethodDefinition]
     /// The names of inherited types.
     let inheritedTypes: [String]
 }
 
-/// A data model representing the definition of an abstract method.
-struct AbstractMethodDefinition: Equatable {
-    /// The name of the abstract method.
+/// A data model representing the definition of a method.
+struct MethodDefinition: Equatable {
+    /// The name of the method.
     let name: String
-    /// The return type of the abstract method.
-    let returnType: String
-    /// The parameter types of the abstract method.
+    /// The return type of the method.
+    let returnType: String?
+    /// The parameter types of the method.
     let parameterTypes: [String]
-    // Parameter names do not need to stored here, since the method
+    /// Indicates if this method is an abstract method.
+    let isAbstract: Bool
+    // Parameter names do not need to be stored here, since the method
     // name encapsulates that already. The parameter label names do
     // no contribute to the uniqueness of methods.
 }
 
-/// A data model representing the definition of an abstract computed
+/// A data model representing the definition of a computed
 /// property.
-struct AbstractVarDefinition: Equatable {
-    /// The name of the abstract method.
+struct VarDefinition: Equatable {
+    /// The name of the property.
     let name: String
-    /// The return type of the abstract method.
+    /// The return type of the property.
     let returnType: String
+    /// Indicates if this property is an abstract method.
+    let isAbstract: Bool
 }

--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/UsageFilterTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/UsageFilterTask.swift
@@ -32,6 +32,8 @@ class UsageFilterTask: BaseFileFilterTask {
     /// - parameter exclusionPaths: The list of path components to check.
     /// If the given URL's path contains any elements in this list, the
     /// URL will be excluded.
+    /// - parameter abstractClassDefinitions: The definitions of all
+    /// abstract classes.
     init(url: URL, exclusionSuffixes: [String], exclusionPaths: [String], abstractClassDefinitions: [AbstractClassDefinition]) {
         self.abstractClassDefinitions = abstractClassDefinitions
         super.init(url: url, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths, taskId: TaskIds.usageFilterTask.rawValue)
@@ -72,6 +74,9 @@ private class UsageFilter: FileFilter {
         let expression = abstractClassNames.joined(separator: "|")
         let regex = Regex(expression)
         return regex.firstMatch(in: content) != nil
+        // Cannot filter out files that also invokes `abstractMethod`,
+        // since a file might contain an abstract class and a concrete
+        // implementation of an abstract class.
     }
 
     // MARK: - Private

--- a/Validator/Sources/AbstractClassValidatorFramework/Utilities/ASTUtils.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Utilities/ASTUtils.swift
@@ -1,0 +1,76 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SourceKittenFramework
+
+/// Extension of SourceKitten `Structure` to provide easy access to a set
+/// of common abstract class AST properties.
+extension Structure {
+
+    /// All the instance properties that invoke `abstractMethod`,
+    /// therefore are abstract properties of this structure. This does
+    /// not include recursive structures.
+    var abstractVars: [VarDefinition] {
+        var definitions = [VarDefinition]()
+
+        var substructures = self.substructures
+        while !substructures.isEmpty {
+            let sub = substructures.removeFirst()
+
+            if let subType = sub.type, subType == .varInstance {
+                // If next substructure is an expression call to `abstractMethod`,
+                // then the current substructure is an abstract var.
+                if let nextSub = substructures.first, nextSub.isExpressionCall && nextSub.name == abstractMethodType {
+                    _ = substructures.removeFirst()
+                    // Properties must have return types.
+                    definitions.append(VarDefinition(name: sub.name, returnType: sub.returnType!, isAbstract: true))
+                }
+            }
+        }
+
+        return definitions
+    }
+
+    /// All the instance methods that invoke `abstractMethod`,
+    /// therefore are abstract methods of this structure. This does
+    /// not include recursive structures.
+    var abstractMethods: [MethodDefinition] {
+        var definitions = [MethodDefinition]()
+
+        for sub in self.substructures {
+            if let subType = sub.type, subType == .functionMethodInstance {
+                // If method structure contains an expression call sub-structure
+                // with the name `abstractMethod`, then this method is an abstract
+                // method.
+                let isAbstract = sub.substructures.contains { (s: Structure) -> Bool in
+                    return s.isExpressionCall && s.name == abstractMethodType
+                }
+                if isAbstract {
+                    let parameterTypes = sub.substructures.compactMap { (s: Structure) -> String? in
+                        if let type = s.type, type == .varParameter {
+                            return s.returnType
+                        }
+                        return nil
+                    }
+                    definitions.append(MethodDefinition(name: sub.name, returnType: sub.returnType, parameterTypes: parameterTypes, isAbstract: true))
+                }
+            }
+        }
+
+        return definitions
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/AbstractClassDefinitionsAggregatorTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/AbstractClassDefinitionsAggregatorTests.swift
@@ -20,14 +20,14 @@ import XCTest
 class AbstractClassDefinitionsAggregatorTests: BaseFrameworkTests {
 
     func test_aggregate_withAncestors_verifyAggregatedResults() {
-        let grandParentVars = [AbstractVarDefinition(name: "gV", returnType: "GV")]
-        let grandParentMethods = [AbstractMethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: []), AbstractMethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"])]
+        let grandParentVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true)]
+        let grandParentMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true), MethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true)]
 
-        let parentVars = [AbstractVarDefinition(name: "pV1", returnType: "PV1"), AbstractVarDefinition(name: "pV2", returnType: "PV2")]
-        let parentMethods = [AbstractMethodDefinition(name: "gM", returnType: "GM", parameterTypes: [])]
+        let parentVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true)]
+        let parentMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true)]
 
-        let childVars = [AbstractVarDefinition(name: "cV", returnType: "CV")]
-        let childMethods = [AbstractMethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"])]
+        let childVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true)]
+        let childMethods = [MethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true)]
 
         let definitions = [
             AbstractClassDefinition(name: "GrandParent", abstractVars: grandParentVars, abstractMethods: grandParentMethods, inheritedTypes: []),

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/DeclarationProducerTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/DeclarationProducerTaskTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 class DeclarationProducerTaskTests: BaseFrameworkTests {
 
-    func test_execute_noExclusion_abstractClass_verifyResult() {
+    func test_execute_noExclusion_fileWithMixedAbstractClasses_verifyResult() {
         let url = fixtureUrl(for: "MixedAbstractClasses.swift")
         let content = try! String(contentsOf: url)
         let task = DeclarationProducerTask(sourceUrl: url, sourceContent: content)
@@ -59,5 +59,44 @@ class DeclarationProducerTaskTests: BaseFrameworkTests {
         let abstractClasses = try! task.execute()
 
         XCTAssertTrue(abstractClasses.isEmpty)
+    }
+
+    func test_execute_noExclusion_fileWithInnerAbstractClasses_verifyResult() {
+        let url = fixtureUrl(for: "NestedAbstractClasses.swift")
+        let content = try! String(contentsOf: url)
+        let task = DeclarationProducerTask(sourceUrl: url, sourceContent: content)
+
+        let abstractClasses = try! task.execute()
+
+        XCTAssertEqual(abstractClasses[0].name, "OutterAbstractClass")
+        XCTAssertEqual(abstractClasses[0].abstractMethods.count, 1)
+        XCTAssertTrue(abstractClasses[0].abstractMethods[0].isAbstract)
+        XCTAssertEqual(abstractClasses[0].abstractMethods[0].name, "paramMethod(_:b:)")
+        XCTAssertEqual(abstractClasses[0].abstractMethods[0].returnType, "PPP")
+        XCTAssertEqual(abstractClasses[0].abstractMethods[0].parameterTypes.count, 2)
+        XCTAssertEqual(abstractClasses[0].abstractMethods[0].parameterTypes[0], "HJJ")
+        XCTAssertEqual(abstractClasses[0].abstractMethods[0].parameterTypes[1], "Bar")
+        XCTAssertEqual(abstractClasses[0].abstractVars.count, 1)
+        XCTAssertTrue(abstractClasses[0].abstractVars[0].isAbstract)
+        XCTAssertEqual(abstractClasses[0].abstractVars[0].name, "someProperty")
+        XCTAssertEqual(abstractClasses[0].abstractVars[0].returnType, "Int")
+
+        XCTAssertEqual(abstractClasses[1].name, "InnerAbstractClassA")
+        XCTAssertEqual(abstractClasses[1].abstractMethods.count, 1)
+        XCTAssertTrue(abstractClasses[1].abstractMethods[0].isAbstract)
+        XCTAssertEqual(abstractClasses[1].abstractMethods[0].name, "innerAbstractMethodA()")
+        XCTAssertNil(abstractClasses[1].abstractMethods[0].returnType)
+        XCTAssertEqual(abstractClasses[1].abstractVars.count, 0)
+
+        XCTAssertEqual(abstractClasses[2].name, "InnerAbstractClassB")
+        XCTAssertEqual(abstractClasses[2].abstractMethods.count, 1)
+        XCTAssertTrue(abstractClasses[2].abstractMethods[0].isAbstract)
+        XCTAssertEqual(abstractClasses[2].abstractMethods[0].name, "yoMethod()")
+        XCTAssertEqual(abstractClasses[2].abstractMethods[0].parameterTypes.count, 0)
+        XCTAssertEqual(abstractClasses[2].abstractMethods[0].returnType, "Yo")
+        XCTAssertEqual(abstractClasses[2].abstractVars.count, 1)
+        XCTAssertTrue(abstractClasses[2].abstractVars[0].isAbstract)
+        XCTAssertEqual(abstractClasses[2].abstractVars[0].name, "innerAbstractVarB")
+        XCTAssertEqual(abstractClasses[2].abstractVars[0].returnType, "Int")
     }
 }

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallCheckerTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallCheckerTests.swift
@@ -26,7 +26,7 @@ class ExpressionCallCheckerTests: BaseFrameworkTests {
     override func setUp() {
         super.setUp()
 
-        let abstractVarDefinition = AbstractVarDefinition(name: "abVar", returnType: "Var")
+        let abstractVarDefinition = VarDefinition(name: "abVar", returnType: "Var", isAbstract: true)
         abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [], inheritedTypes: [])
     }
 

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/NestedAbstractClasses.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/NestedAbstractClasses.swift
@@ -1,0 +1,36 @@
+class RandomClassA {
+    func randomMethod() {
+        
+    }
+}
+
+class OutterAbstractClass: AbstractClass {
+    var someProperty: Int {
+        abstractMethod()
+    }
+
+    var nonAbstractProperty: String {
+        class InnerAbstractClassA: AbstractClass {
+            func innerAbstractMethodA() {
+                abstractMethod()
+            }
+        }
+        return "haha"
+    }
+
+    func someMethod() -> String {
+        class InnerAbstractClassB: AbstractClass {
+            var innerAbstractVarB: Int {
+                abstractMethod()
+            }
+            func yoMethod() -> Yo {
+                abstractMethod()
+            }
+        }
+        return ""
+    }
+
+    func paramMethod(_ a: HJJ, b: Bar) -> PPP {
+        abstractMethod()
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/UsageFilterTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/UsageFilterTaskTests.swift
@@ -24,7 +24,7 @@ class UsageFilterTaskTests: BaseFrameworkTests {
     override func setUp() {
         super.setUp()
 
-        let abstractVarDefinition = AbstractVarDefinition(name: "abVar", returnType: "Var")
+        let abstractVarDefinition = VarDefinition(name: "abVar", returnType: "Var", isAbstract: true)
         abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", abstractVars: [abstractVarDefinition], abstractMethods: [], inheritedTypes: [])
     }
 


### PR DESCRIPTION
The old `abstractVars` parses structures recursively. This means nested classes abstract properties are aggregated at the outter class definitions.

Also made `VarDefinition` and `MethodDefinition` more generic to support future non-abstract definitions.