### PR TITLE
Update usage filter to be specific to constructor invocations

### DIFF
--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/ExpressionCallUsageFilterTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/ExpressionCallUsageFilterTask.swift
@@ -19,9 +19,9 @@ import Foundation
 import SourceParsingFramework
 
 /// A task that checks the various aspects of a file, including if its
-/// content contains any abstract class usages, to determine if the file
-/// should to be processed further.
-class UsageFilterTask: BaseFileFilterTask {
+/// content contains any direct abstract class constructor invocations,
+/// to determine if the file should to be processed further.
+class ExpressionCallUsageFilterTask: BaseFileFilterTask {
 
     /// Initializer.
     ///
@@ -49,7 +49,7 @@ class UsageFilterTask: BaseFileFilterTask {
             definition.name
         }
         return [
-            UsageFilter(content: content, abstractClassNames: abstractClassNames)
+            ExpressionCallUsageFilter(content: content, abstractClassNames: abstractClassNames)
         ]
     }
 
@@ -58,7 +58,7 @@ class UsageFilterTask: BaseFileFilterTask {
     private let abstractClassDefinitions: [AbstractClassDefinition]
 }
 
-private class UsageFilter: FileFilter {
+private class ExpressionCallUsageFilter: FileFilter {
 
     fileprivate init(content: String, abstractClassNames: [String]) {
         self.content = content
@@ -71,7 +71,11 @@ private class UsageFilter: FileFilter {
             return false
         }
 
-        let expression = abstractClassNames.joined(separator: "|")
+        let expression = abstractClassNames
+            .map { (abstractClassName: String) -> String in
+                "(\(abstractClassName) *(.init)? *(\\(|\\{))"
+            }
+            .joined(separator: "|")
         let regex = Regex(expression)
         return regex.firstMatch(in: content) != nil
         // Cannot filter out files that also invokes `abstractMethod`,

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallUsageFilterTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallUsageFilterTaskTests.swift
@@ -17,7 +17,7 @@
 import XCTest
 @testable import AbstractClassValidatorFramework
 
-class UsageFilterTaskTests: BaseFrameworkTests {
+class ExpressionCallUsageFilterTaskTests: BaseFrameworkTests {
 
     private var abstractClassDefinition: AbstractClassDefinition!
 
@@ -30,7 +30,7 @@ class UsageFilterTaskTests: BaseFrameworkTests {
 
     func test_execute_noExclusion_noAbstractClass_verifyResult() {
         let url = fixtureUrl(for: "NoAbstractClass.swift")
-        let task = UsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [])
+        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [])
 
         let result = try! task.execute()
 
@@ -43,8 +43,8 @@ class UsageFilterTaskTests: BaseFrameworkTests {
     }
 
     func test_execute_suffixExclusion_hasAbstractClass_verifyResult() {
-        let url = fixtureUrl(for: "UsageSubclass.swift")
-        let task = UsageFilterTask(url: url, exclusionSuffixes: ["Subclass"], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
+        let url = fixtureUrl(for: "ViolateInstantiation.swift")
+        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: ["Instantiation"], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
 
         let result = try! task.execute()
 
@@ -57,8 +57,8 @@ class UsageFilterTaskTests: BaseFrameworkTests {
     }
 
     func test_execute_pathExclusion_hasAbstractClass_verifyResult() {
-        let url = fixtureUrl(for: "UsageSubclass.swift")
-        let task = UsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: ["Fixtures/"], abstractClassDefinitions: [abstractClassDefinition])
+        let url = fixtureUrl(for: "ViolateInstantiation.swift")
+        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: ["Fixtures/"], abstractClassDefinitions: [abstractClassDefinition])
 
         let result = try! task.execute()
 
@@ -71,23 +71,8 @@ class UsageFilterTaskTests: BaseFrameworkTests {
     }
 
     func test_execute_noExclusion_hasAbstractSubclass_verifyResult() {
-        let url = fixtureUrl(for: "UsageSubclass.swift")
-        let task = UsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
-
-        let result = try! task.execute()
-
-        switch result {
-        case .shouldProcess(let processUrl, let content):
-            XCTAssertEqual(processUrl, url)
-            XCTAssertEqual(content, try! String(contentsOf: url))
-        case .skip:
-            XCTFail()
-        }
-    }
-
-    func test_execute_noExclusion_hasAbstractType_verifyResult() {
-        let url = fixtureUrl(for: "UsageType.swift")
-        let task = UsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
+        let url = fixtureUrl(for: "ViolateInstantiation.swift")
+        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
 
         let result = try! task.execute()
 


### PR DESCRIPTION
This allows two separate filter tasks running two separate validations. This one filters for constructor invocations, which then goes through the `ExpressionCallChecker`. Another filter task will be added to filter for inheritance usages which then validates for the inheritance rule.