### PR TITLE
Integrate expression call validation

### DIFF
--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/ConcreteSubclassProducerTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/ConcreteSubclassProducerTask.swift
@@ -60,7 +60,7 @@ class ConcreteSubclassProducerTask: AbstractTask<[ConcreteSubclassDefinition]> {
                     // sure it is a concrete class.
                     let inheritedTypes = classStructure.inheritedTypes
                     if inheritedTypes.isAnyElement(in: abstractClassNames) {
-                        let hasAbstractVars = classStructure.vars.contains { $0.isAbstract }
+                        let hasAbstractVars = classStructure.computedVars.contains { $0.isAbstract }
                         guard !hasAbstractVars else {
                             return nil
                         }

--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/DeclarationProducerTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/DeclarationProducerTask.swift
@@ -44,7 +44,7 @@ class DeclarationProducerTask: AbstractTask<[AbstractClassDefinition]> {
             return structure
                 .filterSubstructure(by: SwiftDeclarationKind.class.rawValue, recursively: true)
                 .compactMap { (declaration: Structure) -> AbstractClassDefinition? in
-                    let vars = declaration.vars
+                    let vars = declaration.computedVars
                     let hasAbstractVars = vars.contains { $0.isAbstract }
                     let methods = declaration.methods
                     let hasAbstractMethods = methods.contains { $0.isAbstract }

--- a/Validator/Sources/AbstractClassValidatorFramework/Utilities/ASTUtils.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Utilities/ASTUtils.swift
@@ -21,16 +21,21 @@ import SourceKittenFramework
 /// of common abstract class AST properties.
 extension Structure {
 
-    /// All the instance properties of this structure. This does not include
+    /// All the computed properties of this structure. This does not include
     /// recursive structures.
-    var vars: [VarDefinition] {
+    var computedVars: [VarDefinition] {
         var definitions = [VarDefinition]()
 
         var substructures = self.substructures
         while !substructures.isEmpty {
             let sub = substructures.removeFirst()
 
-            if let subType = sub.type, subType == .varInstance {
+            // Swift compiler ensures overriding computed properties must
+            // have explicit types, and cannot be stored properties. If
+            // the substructure does not have a return type, then it's not
+            // a computed property. Therefore it cannot be abstract or an
+            // override of an abstract property. So we do not have to parse.
+            if let subType = sub.type, subType == .varInstance, let returnType = sub.returnType {
                 // If next substructure is an expression call to `abstractMethod`,
                 // then the current substructure is an abstract var.
                 let isAbstract: Bool
@@ -44,7 +49,7 @@ extension Structure {
                 }
 
                 // Properties must have return types.
-                definitions.append(VarDefinition(name: sub.name, returnType: sub.returnType!, isAbstract: isAbstract))
+                definitions.append(VarDefinition(name: sub.name, returnType: returnType, isAbstract: isAbstract))
             }
         }
 

--- a/Validator/Sources/AbstractClassValidatorFramework/Validator.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Validator.swift
@@ -64,10 +64,14 @@ public class Validator {
         }
 
         let executor = createExecutor(withName: "AbstractClassValidator.validate", shouldTrackTaskId: shouldCollectParsingInfo, concurrencyLimit: concurrencyLimit)
+        let abstractClassDefinitions = try parseAbstractClassDefinitions(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, waitUpTo: timeout)
 
+        try validateExpressionCalls(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, against: abstractClassDefinitions, using: executor, waitUpTo: timeout)
     }
 
     // MARK: - Private
+
+    // MARK: - Task Execution
 
     private func createExecutor(withName name: String, shouldTrackTaskId: Bool, concurrencyLimit: Int?) -> SequenceExecutor {
         #if DEBUG
@@ -75,5 +79,98 @@ public class Validator {
         #else
             return ConcurrentSequenceExecutor(name: name, qos: .userInteractive, shouldTrackTaskId: shouldTrackTaskId, maxConcurrentTasks: concurrencyLimit)
         #endif
+    }
+
+    private func executeAndCollectTaskHandles<ResultType>(with rootUrls: [URL], sourcesListFormatValue: String?, execution: (URL) -> SequenceExecutionHandle<ResultType>) throws -> [(SequenceExecutionHandle<ResultType>, URL)] {
+        var urlHandles = [(SequenceExecutionHandle<ResultType>, URL)]()
+
+        // Enumerate all files and execute parsing sequences concurrently.
+        let enumerator = FileEnumerator()
+        for url in rootUrls {
+            try enumerator.enumerate(from: url, withSourcesListFormat: sourcesListFormatValue) { (fileUrl: URL) in
+                let taskHandle = execution(fileUrl)
+                urlHandles.append((taskHandle, fileUrl))
+            }
+        }
+
+        return urlHandles
+    }
+
+    // MARK: - Abstract Class Definitions
+
+    private func parseAbstractClassDefinitions(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], using executor: SequenceExecutor, waitUpTo timeout: TimeInterval) throws -> [AbstractClassDefinition] {
+        // Parse all URLs.
+        let urlTaskHandles = try executeAndCollectTaskHandles(with: sourceRootUrls, sourcesListFormatValue: sourcesListFormatValue) { (fileUrl: URL) -> SequenceExecutionHandle<[AbstractClassDefinition]> in
+            let filterTask = DeclarationFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths)
+
+            return executor.executeSequence(from: filterTask) { (currentTask: Task, currentResult: Any) -> SequenceExecution<[AbstractClassDefinition]> in
+                if currentTask is DeclarationFilterTask, let filterResult = currentResult as? FilterResult {
+                    switch filterResult {
+                    case .shouldProcess(let url, let content):
+                        return .continueSequence(DeclarationProducerTask(sourceUrl: url, sourceContent: content))
+                    case .skip:
+                        return .endOfSequence([AbstractClassDefinition]())
+                    }
+                } else if currentTask is DeclarationProducerTask, let definitions = currentResult as? [AbstractClassDefinition] {
+                    return .endOfSequence(definitions)
+                } else {
+                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
+                }
+            }
+        }
+
+        // Wait for parsing results.
+        var definitions = [AbstractClassDefinition]()
+        for urlHandle in urlTaskHandles {
+            do {
+                let result = try urlHandle.0.await(withTimeout: timeout)
+                definitions.append(contentsOf: result)
+            } catch SequenceExecutionError.awaitTimeout(let taskId) {
+                throw GenericError.withMessage("Processing \(urlHandle.1.path) timed out while executing task with Id \(taskId)")
+            } catch {
+                throw error
+            }
+        }
+
+        return definitions
+    }
+
+    // MARK: - Expression Call Validation
+
+    private func validateExpressionCalls(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], against abstractClassDefinitions: [AbstractClassDefinition], using executor: SequenceExecutor, waitUpTo timeout: TimeInterval) throws {
+        let urlTaskHandles = try executeAndCollectTaskHandles(with: sourceRootUrls, sourcesListFormatValue: sourcesListFormatValue) { (fileUrl: URL) -> SequenceExecutionHandle<ValidationResult> in
+            let filterTask = ExpressionCallUsageFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths, abstractClassDefinitions: abstractClassDefinitions)
+
+            return executor.executeSequence(from: filterTask) { (currentTask: Task, currentResult: Any) -> SequenceExecution<ValidationResult> in
+                if currentTask is ExpressionCallUsageFilterTask, let filterResult = currentResult as? FilterResult {
+                    switch filterResult {
+                    case .shouldProcess(let url, let content):
+                        return .continueSequence(ExpressionCallValidationTask(sourceUrl: url, sourceContent: content, abstractClassDefinitions: abstractClassDefinitions))
+                    case .skip:
+                        return .endOfSequence(.success)
+                    }
+                } else if currentTask is ExpressionCallValidationTask, let validationResult = currentResult as? ValidationResult {
+                    return .endOfSequence(validationResult)
+                } else {
+                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
+                }
+            }
+        }
+
+        for urlHandle in urlTaskHandles {
+            do {
+                let result = try urlHandle.0.await(withTimeout: timeout)
+                switch result {
+                case .success:
+                    break
+                case .failureWithReason(let reason):
+                    throw GenericError.withMessage(reason)
+                }
+            } catch SequenceExecutionError.awaitTimeout(let taskId) {
+                throw GenericError.withMessage("Processing \(urlHandle.1.path) timed out while executing task with Id \(taskId)")
+            } catch {
+                throw error
+            }
+        }
     }
 }

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ConcreteSubclass/ChildConcrete.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ConcreteSubclass/ChildConcrete.swift
@@ -1,0 +1,14 @@
+class ChildConcrete: ChildAbstract {
+
+    override var gpAbstractVar: GPVar {
+        return GPVar()
+    }
+
+    override func pAbstractMethod(arg1: Int) -> PMethod {
+        return PMethod(arg: arg1)
+    }
+
+    override func cAbstractMethod(_ a: Arg1, b: ArgB) -> CMethod {
+        return CMethod(a: a, b: b)
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ConcreteSubclass/GrandParentAbstract.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ConcreteSubclass/GrandParentAbstract.swift
@@ -1,0 +1,19 @@
+class GrandParentAbstract: AbstractClass {
+    var gpAbstractVar: GPVar {
+        abstractMethod()
+    }
+
+    let gpLet = "haha"
+
+    var gpConcreteVar: Int {
+        return 21
+    }
+
+    func gpConcreteMethod() -> String {
+        return "blah"
+    }
+
+    func gpAbstractMethod() -> GPMethod {
+        abstractMethod()
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ConcreteSubclass/ParentAbstractChildAbstractNested.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ConcreteSubclass/ParentAbstractChildAbstractNested.swift
@@ -1,0 +1,32 @@
+class ParentAbstract: GrandParentAbstract {
+
+    var pConcreteVar: PVar {
+        return PVar()
+    }
+
+    func pConcreteMethod() -> Blah {
+        return Blah()
+    }
+
+    func pAbstractMethod(arg1: Int) -> PMethod {
+        abstractMethod()
+    }
+
+    class ChildAbstract: ParentAbstract {
+        var cAbstractVar: CVar {
+            abstractMethod()
+        }
+
+        var cConcreteVar: ChildConcrete {
+            return ChildConcrete()
+        }
+
+        func cAbstractMethod(_ a: Arg1, b: ArgB) -> CMethod {
+            abstractMethod()
+        }
+
+        func cConcreteMethod() -> Int {
+            return 12
+        }
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ExpressionCall/AbstractInstantiation.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ExpressionCall/AbstractInstantiation.swift
@@ -1,0 +1,6 @@
+class BadInstantiation {
+
+    var child: ChildAbstract {
+        return ChildAbstract()
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ExpressionCall/GrandParentAbstract.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ExpressionCall/GrandParentAbstract.swift
@@ -1,0 +1,19 @@
+class GrandParentAbstract: AbstractClass {
+    var gpAbstractVar: GPVar {
+        abstractMethod()
+    }
+
+    let gpLet = "haha"
+
+    var gpConcreteVar: Int {
+        return 21
+    }
+
+    func gpConcreteMethod() -> String {
+        return "blah"
+    }
+
+    func gpAbstractMethod() -> GPMethod {
+        abstractMethod()
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ExpressionCall/ParentAbstractChildAbstractNested.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/ExpressionCall/ParentAbstractChildAbstractNested.swift
@@ -1,0 +1,32 @@
+class ParentAbstract: GrandParentAbstract {
+
+    var pConcreteVar: PVar {
+        return PVar()
+    }
+
+    func pConcreteMethod() -> Blah {
+        return Blah()
+    }
+
+    func pAbstractMethod(arg1: Int) -> PMethod {
+        abstractMethod()
+    }
+
+    class ChildAbstract: ParentAbstract {
+        var cAbstractVar: CVar {
+            abstractMethod()
+        }
+
+        var cConcreteVar: ChildConcrete {
+            return ChildConcrete()
+        }
+
+        func cAbstractMethod(_ a: Arg1, b: ArgB) -> CMethod {
+            abstractMethod()
+        }
+
+        func cConcreteMethod() -> Int {
+            return 12
+        }
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Valid/ChildConcrete.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Valid/ChildConcrete.swift
@@ -1,0 +1,22 @@
+class ChildConcrete: ChildAbstract {
+
+    override var gpAbstractVar: GPVar {
+        return GPVar()
+    }
+
+    override var cAbstractVar: CVar {
+        return CVar()
+    }
+
+    override func gpAbstractMethod() -> GPMethod {
+        return GPMethod()
+    }
+
+    override func pAbstractMethod(arg1: Int) -> PMethod {
+        return PMethod(arg: arg1)
+    }
+
+    override func cAbstractMethod(_ a: Arg1, b: ArgB) -> CMethod {
+        return CMethod(a: a, b: b)
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Valid/GrandParentAbstract.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Valid/GrandParentAbstract.swift
@@ -1,0 +1,19 @@
+class GrandParentAbstract: AbstractClass {
+    var gpAbstractVar: GPVar {
+        abstractMethod()
+    }
+
+    let gpLet = "haha"
+
+    var gpConcreteVar: Int {
+        return 21
+    }
+
+    func gpConcreteMethod() -> String {
+        return "blah"
+    }
+
+    func gpAbstractMethod() -> GPMethod {
+        abstractMethod()
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Valid/ParentAbstractChildAbstractNested.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Valid/ParentAbstractChildAbstractNested.swift
@@ -1,0 +1,32 @@
+class ParentAbstract: GrandParentAbstract {
+
+    var pConcreteVar: PVar {
+        return PVar()
+    }
+
+    func pConcreteMethod() -> Blah {
+        return Blah()
+    }
+
+    func pAbstractMethod(arg1: Int) -> PMethod {
+        abstractMethod()
+    }
+
+    class ChildAbstract: ParentAbstract {
+        var cAbstractVar: CVar {
+            abstractMethod()
+        }
+
+        var cConcreteVar: ChildConcrete {
+            return ChildConcrete()
+        }
+
+        func cAbstractMethod(_ a: Arg1, b: ArgB) -> CMethod {
+            abstractMethod()
+        }
+
+        func cConcreteMethod() -> Int {
+            return 12
+        }
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ValidatorTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ValidatorTests.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SourceKittenFramework
+import SourceParsingFramework
+import XCTest
+@testable import AbstractClassValidatorFramework
+
+class ValidatorTests: BaseFrameworkTests {
+
+    func test_validate_noExclusions_withNoViolations_verifySuccess() {
+        let sourceRoot = fixtureUrl(for: "/Integration/Valid/")
+
+        try! Validator().validate(from: [sourceRoot.path], excludingFilesEndingWith: [], excludingFilesWithPaths: [], shouldCollectParsingInfo: false, timeout: 10, concurrencyLimit: nil)
+    }
+
+    func test_validate_exclusionPath_withViolations_verifySuccess() {
+        let sourceRoot = fixtureUrl(for: "/Integration/Invalid/")
+
+        try! Validator().validate(from: [sourceRoot.path], excludingFilesEndingWith: [], excludingFilesWithPaths: ["/Integration"], shouldCollectParsingInfo: false, timeout: 10, concurrencyLimit: nil)
+    }
+
+    func test_validate_exclusionSuffix_withViolations_verifySuccess() {
+        let sourceRoot = fixtureUrl(for: "/Integration/Invalid/")
+
+        try! Validator().validate(from: [sourceRoot.path], excludingFilesEndingWith: ["Concrete", "Instantiation"], excludingFilesWithPaths: [], shouldCollectParsingInfo: false, timeout: 10, concurrencyLimit: nil)
+    }
+
+    func test_validate_noExclusions_withExpressionCallViolations_verifyError() {
+        let sourceRoot = fixtureUrl(for: "/Integration/Invalid/ExpressionCall/")
+
+        do {
+            try Validator().validate(from: [sourceRoot.path], excludingFilesEndingWith: [], excludingFilesWithPaths: [], shouldCollectParsingInfo: false, timeout: 10, concurrencyLimit: nil)
+            XCTFail()
+        } catch GenericError.withMessage(let message) {
+            XCTAssertTrue(message.contains("ChildAbstract"))
+            XCTAssertTrue(message.contains("/Fixtures/Integration/Invalid/ExpressionCall/AbstractInstantiation.swift"))
+        } catch {
+            XCTFail()
+        }
+    }
+}


### PR DESCRIPTION
Also fixed a bug in `ASTUtils` where force unwrapping a property's return type can cause a crash, since stored properties may not have explicit return type. This has been updated to just include computed properties, since they all must have explicit types. At the same time, for abstract properties purposes, stored properties are irrelevant, since they cannot be abstract.