### PR TITLE
Use print and exit to repot error

### DIFF
--- a/Validator/Sources/abstractclassvalidator/ValidateCommand.swift
+++ b/Validator/Sources/abstractclassvalidator/ValidateCommand.swift
@@ -66,7 +66,8 @@ class ValidateCommand: AbstractCommand {
             do {
                 try Validator().validate(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, shouldCollectParsingInfo: shouldCollectParsingInfo, timeout: timeout, concurrencyLimit: concurrencyLimit)
             } catch GenericError.withMessage(let message) {
-                fatalError(message)
+                print(message)
+                exit(1)
             } catch {
                 fatalError("Unknown error: \(error)")
             }


### PR DESCRIPTION
Using `fatalError` cannot be captured by a script that is used to integrate with build systems.