### PR TITLE
Fix subclass filter and producer tasks to include generic abstract cl…

### DIFF
--- a/Validator/Sources/AbstractClassValidatorFramework/Models/AbstractClassDefinition.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Models/AbstractClassDefinition.swift
@@ -41,6 +41,8 @@ struct MethodDefinition: Hashable {
     let parameterTypes: [String]
     /// Indicates if this method is an abstract method.
     let isAbstract: Bool
+    /// Indicates if this property has the override attribute.
+    let isOverride: Bool
     // Parameter names do not need to be stored here, since the method
     // name encapsulates that already. The parameter label names do
     // no contribute to the uniqueness of methods.
@@ -55,6 +57,8 @@ struct VarDefinition: Hashable {
     let returnType: String
     /// Indicates if this property is an abstract method.
     let isAbstract: Bool
+    /// Indicates if this property has the override attribute.
+    let isOverride: Bool
 }
 
 /// A data model representing the definition of an abstract class that

--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/ConcreteSubclassProducerTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/ConcreteSubclassProducerTask.swift
@@ -58,7 +58,7 @@ class ConcreteSubclassProducerTask: AbstractTask<[ConcreteSubclassDefinition]> {
                 .compactMap { (classStructure: Structure) -> ConcreteSubclassDefinition? in
                     // If the class inherits from an abstract class, make
                     // sure it is a concrete class.
-                    let inheritedTypes = classStructure.inheritedTypes
+                    let inheritedTypes = classStructure.inheritedTypeNames
                     if inheritedTypes.isAnyElement(in: abstractClassNames) {
                         let hasAbstractVars = classStructure.computedVars.contains { $0.isAbstract }
                         guard !hasAbstractVars else {
@@ -89,14 +89,14 @@ private extension Structure {
     var varDefinitions: [VarDefinition] {
         return filterSubstructure(by: SwiftDeclarationKind.varInstance.rawValue, recursively: false)
             .map { (varStructure) -> VarDefinition in
-                VarDefinition(name: varStructure.name, returnType: varStructure.returnType!, isAbstract: false)
+                VarDefinition(name: varStructure.name, returnType: varStructure.returnType!, isAbstract: false, isOverride: varStructure.isOverride)
             }
     }
 
     var methodDefinitions: [MethodDefinition] {
         return filterSubstructure(by: SwiftDeclarationKind.functionMethodInstance.rawValue, recursively: false)
             .map { (methodStructure) -> MethodDefinition in
-                MethodDefinition(name: methodStructure.name, returnType: methodStructure.returnType, parameterTypes: methodStructure.parameterTypes, isAbstract: false)
+                MethodDefinition(name: methodStructure.name, returnType: methodStructure.returnType, parameterTypes: methodStructure.parameterTypes, isAbstract: false, isOverride: methodStructure.isOverride)
             }
     }
 }

--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/DeclarationProducerTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/DeclarationProducerTask.swift
@@ -49,7 +49,7 @@ class DeclarationProducerTask: AbstractTask<[AbstractClassDefinition]> {
                     let methods = declaration.methods
                     let hasAbstractMethods = methods.contains { $0.isAbstract }
                     if hasAbstractVars || hasAbstractMethods {
-                        return AbstractClassDefinition(name: declaration.name, vars: vars, methods: methods, inheritedTypes: declaration.inheritedTypes)
+                        return AbstractClassDefinition(name: declaration.name, vars: vars, methods: methods, inheritedTypes: declaration.inheritedTypeNames)
                     }
                     return nil
                 }

--- a/Validator/Sources/AbstractClassValidatorFramework/Tasks/SubclassUsageFilterTask.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Tasks/SubclassUsageFilterTask.swift
@@ -36,7 +36,7 @@ class SubclassUsageFilterTask: BaseRegexUsageFilterTask {
     /// abstract classes.
     init(url: URL, exclusionSuffixes: [String], exclusionPaths: [String], abstractClassDefinitions: [AbstractClassDefinition]) {
         super.init(url: url, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths, abstractClassDefinitions: abstractClassDefinitions, taskId: .subclassUsageFilterTask) { (abstractClassDefinition: AbstractClassDefinition) in
-            "(: *\(abstractClassDefinition.name) *(\\(|\\{))"
+            "(:( |.)*\(abstractClassDefinition.name) *(\\(|\\{|\\<|,))"
             // Cannot filter out files that also contain known abstract
             // classes, since a file might contain an abstract class and
             // a concrete implementation of an abstract class.

--- a/Validator/Sources/AbstractClassValidatorFramework/Utilities/ASTUtils.swift
+++ b/Validator/Sources/AbstractClassValidatorFramework/Utilities/ASTUtils.swift
@@ -49,7 +49,7 @@ extension Structure {
                 }
 
                 // Properties must have return types.
-                definitions.append(VarDefinition(name: sub.name, returnType: returnType, isAbstract: isAbstract))
+                definitions.append(VarDefinition(name: sub.name, returnType: returnType, isAbstract: isAbstract, isOverride: sub.isOverride))
             }
         }
 
@@ -67,7 +67,7 @@ extension Structure {
                 let isAbstract = methodStructure.substructures.contains { (substructure: Structure) -> Bool in
                     return substructure.isExpressionCall && substructure.name == abstractMethodType
                 }
-                return MethodDefinition(name: methodStructure.name, returnType: methodStructure.returnType, parameterTypes: methodStructure.parameterTypes, isAbstract: isAbstract)
+                return MethodDefinition(name: methodStructure.name, returnType: methodStructure.returnType, parameterTypes: methodStructure.parameterTypes, isAbstract: isAbstract, isOverride: methodStructure.isOverride)
         }
     }
 

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/AbstractClassDefinitionsAggregatorTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/AbstractClassDefinitionsAggregatorTests.swift
@@ -20,14 +20,14 @@ import XCTest
 class AbstractClassDefinitionsAggregatorTests: BaseFrameworkTests {
 
     func test_aggregate_withAncestors_verifyAggregatedResults() {
-        let grandParentVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true)]
-        let grandParentMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true), MethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true)]
+        let grandParentVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true, isOverride: false)]
+        let grandParentMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true, isOverride: false), MethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true, isOverride: false)]
 
-        let parentVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true)]
-        let parentMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true)]
+        let parentVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true, isOverride: false), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true, isOverride: false)]
+        let parentMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true, isOverride: false)]
 
-        let childVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true)]
-        let childMethods = [MethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true)]
+        let childVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true, isOverride: false)]
+        let childMethods = [MethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true, isOverride: false)]
 
         let definitions = [
             AbstractClassDefinition(name: "GrandParent", vars: grandParentVars, methods: grandParentMethods, inheritedTypes: []),

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassDefinitionsAggregatorTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassDefinitionsAggregatorTests.swift
@@ -20,14 +20,14 @@ import XCTest
 class ConcreteSubclassDefinitionsAggregatorTests: BaseFrameworkTests {
 
     func test_aggregate_withAncestors_verifyAggregatedResults() {
-        let grandParentVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true)]
-        let grandParentMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true), MethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true)]
+        let grandParentVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true, isOverride: false)]
+        let grandParentMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true, isOverride: false), MethodDefinition(name: "gM2", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true, isOverride: false)]
 
-        let parentVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true)]
-        let parentMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true)]
+        let parentVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true, isOverride: false), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true, isOverride: false)]
+        let parentMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true, isOverride: false)]
 
-        let childVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true)]
-        let childMethods = [MethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true)]
+        let childVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true, isOverride: false)]
+        let childMethods = [MethodDefinition(name: "cM", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true, isOverride: false)]
 
         let grandParentAbstractClass = AbstractClassDefinition(name: "GrandParent", vars: grandParentVars, methods: grandParentMethods, inheritedTypes: [])
         let parentAbstractClass = AbstractClassDefinition(name: "Parent", vars: parentVars, methods: parentMethods, inheritedTypes: ["GrandParent"])
@@ -38,12 +38,12 @@ class ConcreteSubclassDefinitionsAggregatorTests: BaseFrameworkTests {
             AggregatedAbstractClassDefinition(value: childAbstractClass, aggregatedVars: grandParentVars + parentVars + childVars, aggregatedMethods: grandParentMethods + parentMethods + childMethods),
             ]
 
-        let parentLeafVars = [VarDefinition(name: "pLV", returnType: "PLV", isAbstract: false)]
-        let parentLeafMethods = [MethodDefinition(name: "pLM", returnType: "PLM", parameterTypes: [], isAbstract: false)]
+        let parentLeafVars = [VarDefinition(name: "pLV", returnType: "PLV", isAbstract: false, isOverride: true)]
+        let parentLeafMethods = [MethodDefinition(name: "pLM", returnType: "PLM", parameterTypes: [], isAbstract: false, isOverride: true)]
 
-        let childLeafVars = [VarDefinition(name: "cLV1", returnType: "CLV1", isAbstract: false),
-                             VarDefinition(name: "cLV2", returnType: "CLV2", isAbstract: false)]
-        let childLeafMethods = [MethodDefinition(name: "cLM", returnType: "CLM", parameterTypes: [], isAbstract: false)]
+        let childLeafVars = [VarDefinition(name: "cLV1", returnType: "CLV1", isAbstract: false, isOverride: true),
+                             VarDefinition(name: "cLV2", returnType: "CLV2", isAbstract: false, isOverride: true)]
+        let childLeafMethods = [MethodDefinition(name: "cLM", returnType: "CLM", parameterTypes: [], isAbstract: false, isOverride: true)]
 
         let leafConcreteSubclassDefinitions = [
             ConcreteSubclassDefinition(name: "ParentLeaf", vars: parentLeafVars, methods: parentLeafMethods, inheritedTypes: ["GrandParent", "Parent"], filePath: URL(fileURLWithPath: #file).path),

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassProducerTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassProducerTaskTests.swift
@@ -22,7 +22,7 @@ class ConcreteSubclassProducerTaskTests: BaseFrameworkTests {
     func test_execute_hasAbstractSubclass_verifyNoDefinitions() {
         let url = fixtureUrl(for: "MiddleAbstractClass.swift")
         let content = try! String(contentsOf: url)
-        let abstractClassDefinitions = [AbstractClassDefinition(name: "GrandParentAbstractClass", vars: [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: true)], methods: [], inheritedTypes: ["AbstractClass"])]
+        let abstractClassDefinitions = [AbstractClassDefinition(name: "GrandParentAbstractClass", vars: [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: true, isOverride: false)], methods: [], inheritedTypes: ["AbstractClass"])]
 
         let task = ConcreteSubclassProducerTask(sourceUrl: url, sourceContent: content, abstractClassDefinitions: abstractClassDefinitions)
 
@@ -35,8 +35,8 @@ class ConcreteSubclassProducerTaskTests: BaseFrameworkTests {
         let url = fixtureUrl(for: "ConcreteSubclass.swift")
         let content = try! String(contentsOf: url)
         let abstractClassDefinitions = [
-            AbstractClassDefinition(name: "GrandParentAbstractClass", vars: [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: true)], methods: [], inheritedTypes: ["AbstractClass"]),
-            AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: true)], inheritedTypes: ["GrandParentAbstractClass"])
+            AbstractClassDefinition(name: "GrandParentAbstractClass", vars: [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: true, isOverride: false)], methods: [], inheritedTypes: ["AbstractClass"]),
+            AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: true, isOverride: false)], inheritedTypes: ["GrandParentAbstractClass"])
         ]
 
         let task = ConcreteSubclassProducerTask(sourceUrl: url, sourceContent: content, abstractClassDefinitions: abstractClassDefinitions)
@@ -46,13 +46,13 @@ class ConcreteSubclassProducerTaskTests: BaseFrameworkTests {
         XCTAssertEqual(concreteDefinitions.count, 2)
 
         XCTAssertEqual(concreteDefinitions[0].name, "ConcreteClass1")
-        XCTAssertEqual(concreteDefinitions[0].vars, [VarDefinition(name: "someProperty", returnType: "SomeAbstractC", isAbstract: false),
-                                                           VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: false)])
-        XCTAssertEqual(concreteDefinitions[0].methods, [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: false)])
+        XCTAssertEqual(concreteDefinitions[0].vars, [VarDefinition(name: "someProperty", returnType: "SomeAbstractC", isAbstract: false, isOverride: false),
+                                                           VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: false, isOverride: true)])
+        XCTAssertEqual(concreteDefinitions[0].methods, [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: false, isOverride: true)])
         XCTAssertEqual(concreteDefinitions[0].inheritedTypes, ["ParentAbstractClass", "AProtocol"])
 
         XCTAssertEqual(concreteDefinitions[1].name, "ConcreteClass2")
-        XCTAssertEqual(concreteDefinitions[1].vars, [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: false)])
+        XCTAssertEqual(concreteDefinitions[1].vars, [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: false, isOverride: true)])
         XCTAssertEqual(concreteDefinitions[1].inheritedTypes, ["GrandParentAbstractClass"])
     }
 
@@ -60,8 +60,8 @@ class ConcreteSubclassProducerTaskTests: BaseFrameworkTests {
         let url = fixtureUrl(for: "InnerConcreteSubclass.swift")
         let content = try! String(contentsOf: url)
         let abstractClassDefinitions = [
-            AbstractClassDefinition(name: "GrandParentAbstractClass", vars: [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: true)], methods: [], inheritedTypes: ["AbstractClass"]),
-            AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: true)], inheritedTypes: ["GrandParentAbstractClass"])
+            AbstractClassDefinition(name: "GrandParentAbstractClass", vars: [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: true, isOverride: false)], methods: [], inheritedTypes: ["AbstractClass"]),
+            AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: true, isOverride: false)], inheritedTypes: ["GrandParentAbstractClass"])
         ]
 
         let task = ConcreteSubclassProducerTask(sourceUrl: url, sourceContent: content, abstractClassDefinitions: abstractClassDefinitions)
@@ -71,7 +71,30 @@ class ConcreteSubclassProducerTaskTests: BaseFrameworkTests {
         XCTAssertEqual(concreteDefinitions.count, 1)
 
         XCTAssertEqual(concreteDefinitions[0].name, "ConcreteClass2")
-        XCTAssertEqual(concreteDefinitions[0].vars, [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: false)])
+        XCTAssertEqual(concreteDefinitions[0].vars, [VarDefinition(name: "grandParentVar", returnType: "GrandParentVar", isAbstract: false, isOverride: true)])
         XCTAssertEqual(concreteDefinitions[0].inheritedTypes, ["GrandParentAbstractClass"])
+    }
+
+    func test_execute_hasGenericBaseClassAndConcreteSubclass_verifyDefinition() {
+        let url = fixtureUrl(for: "GenericSuperConcreteSubclass.swift")
+        let content = try! String(contentsOf: url)
+        let abstractClassDefinitions = [
+            AbstractClassDefinition(name: "GenericBaseClass", vars: [VarDefinition(name: "genericTypeVar", returnType: "GrandParentVar", isAbstract: true, isOverride: false)], methods: [], inheritedTypes: ["AbstractClass"]),
+            AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [MethodDefinition(name: "parentMethod(index:)", returnType: "String", parameterTypes: ["Int"], isAbstract: true, isOverride: false)], inheritedTypes: ["GrandParentAbstractClass"])
+        ]
+
+        let task = ConcreteSubclassProducerTask(sourceUrl: url, sourceContent: content, abstractClassDefinitions: abstractClassDefinitions)
+
+        let concreteDefinitions = try! task.execute()
+
+        XCTAssertEqual(concreteDefinitions.count, 1)
+
+        XCTAssertEqual(concreteDefinitions[0].name, "ConcreteClassGenericType")
+        XCTAssertEqual(concreteDefinitions[0].vars.count, 1)
+        XCTAssertEqual(concreteDefinitions[0].vars, [VarDefinition(name: "genericTypeVar", returnType: "String", isAbstract: false, isOverride: true)])
+        XCTAssertEqual(concreteDefinitions[0].methods.count, 1)
+        XCTAssertEqual(concreteDefinitions[0].methods[0].name, "returnGenericType()")
+        XCTAssertEqual(concreteDefinitions[0].methods[0].returnType, "String")
+        XCTAssertEqual(concreteDefinitions[0].inheritedTypes, ["AProtocol", "GenericBaseClass"])
     }
 }

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassValidationTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassValidationTaskTests.swift
@@ -50,30 +50,30 @@ class ConcreteSubclassValidationTaskTests: BaseFrameworkTests {
     override func setUp() {
         super.setUp()
 
-        grandParentAbstractVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true)]
-        grandParentConcreteVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: false)]
+        grandParentAbstractVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: true, isOverride: false)]
+        grandParentConcreteVars = [VarDefinition(name: "gV", returnType: "GV", isAbstract: false, isOverride: true)]
 
-        grandParentAbstractMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true), MethodDefinition(name: "gM2(_:arg2:)", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true)]
-        grandParentConcreteMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: false), MethodDefinition(name: "gM2(_:arg2:)", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: false)]
+        grandParentAbstractMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: true, isOverride: false), MethodDefinition(name: "gM2(_:arg2:)", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: true, isOverride: false)]
+        grandParentConcreteMethods = [MethodDefinition(name: "gM1", returnType: "GM1", parameterTypes: [], isAbstract: false, isOverride: true), MethodDefinition(name: "gM2(_:arg2:)", returnType: "GM2", parameterTypes: ["GMP1", "GMP2"], isAbstract: false, isOverride: true)]
 
-        parentAbstractVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true)]
-        parentConcreteVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: false), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: false)]
+        parentAbstractVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: true, isOverride: false), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: true, isOverride: false)]
+        parentConcreteVars = [VarDefinition(name: "pV1", returnType: "PV1", isAbstract: false, isOverride: true), VarDefinition(name: "pV2", returnType: "PV2", isAbstract: false, isOverride: true)]
 
-        parentAbstractMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true)]
-        parentConcreteMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: false)]
+        parentAbstractMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: true, isOverride: false)]
+        parentConcreteMethods = [MethodDefinition(name: "gM", returnType: "GM", parameterTypes: [], isAbstract: false, isOverride: true)]
 
-        childAbstractVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true)]
-        childConcreteVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: false)]
+        childAbstractVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: true, isOverride: false)]
+        childConcreteVars = [VarDefinition(name: "cV", returnType: "CV", isAbstract: false, isOverride: true)]
 
-        childAbstractMethods = [MethodDefinition(name: "cM(arg:)", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true)]
-        childConcreteMethods = [MethodDefinition(name: "cM(arg:)", returnType: "CM", parameterTypes: ["CMP"], isAbstract: false)]
+        childAbstractMethods = [MethodDefinition(name: "cM(arg:)", returnType: "CM", parameterTypes: ["CMP"], isAbstract: true, isOverride: false)]
+        childConcreteMethods = [MethodDefinition(name: "cM(arg:)", returnType: "CM", parameterTypes: ["CMP"], isAbstract: false, isOverride: true)]
 
-        parentAdditionalConcreteVars = [VarDefinition(name: "pLV", returnType: "PLV", isAbstract: false)]
-        parentAdditionalConcreteMethods = [MethodDefinition(name: "pLM", returnType: "PLM", parameterTypes: [], isAbstract: false)]
+        parentAdditionalConcreteVars = [VarDefinition(name: "pLV", returnType: "PLV", isAbstract: false, isOverride: true)]
+        parentAdditionalConcreteMethods = [MethodDefinition(name: "pLM", returnType: "PLM", parameterTypes: [], isAbstract: false, isOverride: true)]
 
-        childAdditionalConcreteVars = [VarDefinition(name: "cLV1", returnType: "CLV1", isAbstract: false),
-                             VarDefinition(name: "cLV2", returnType: "CLV2", isAbstract: false)]
-        childAdditionalConcreteMethods = [MethodDefinition(name: "cLM", returnType: "CLM", parameterTypes: [], isAbstract: false)]
+        childAdditionalConcreteVars = [VarDefinition(name: "cLV1", returnType: "CLV1", isAbstract: false, isOverride: true),
+                             VarDefinition(name: "cLV2", returnType: "CLV2", isAbstract: false, isOverride: true)]
+        childAdditionalConcreteMethods = [MethodDefinition(name: "cLM", returnType: "CLM", parameterTypes: [], isAbstract: false, isOverride: true)]
 
         parentConcreteClass = ConcreteSubclassDefinition(name: "ParentLeaf", vars: parentAdditionalConcreteVars, methods: parentAdditionalConcreteMethods, inheritedTypes: ["GrandParent", "Parent"], filePath: URL(fileURLWithPath: #file).path)
         childConcreteClass = ConcreteSubclassDefinition(name: "ChildLeaf", vars: childAdditionalConcreteVars, methods: childAdditionalConcreteMethods, inheritedTypes: ["GrandParent", "Parent", "Child"], filePath: URL(fileURLWithPath: #file).path)

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallValidationTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ExpressionCallValidationTaskTests.swift
@@ -26,7 +26,7 @@ class ExpressionCallValidationTaskTests: BaseFrameworkTests {
     override func setUp() {
         super.setUp()
 
-        let abstractVarDefinition = VarDefinition(name: "abVar", returnType: "Var", isAbstract: true)
+        let abstractVarDefinition = VarDefinition(name: "abVar", returnType: "Var", isAbstract: true, isOverride: false)
         abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", vars: [abstractVarDefinition], methods: [], inheritedTypes: [])
     }
 

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/ConcreteSubclass.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/ConcreteSubclass.swift
@@ -3,17 +3,17 @@ class ConcreteClass1: ParentAbstractClass, AProtocol {
         return SomeAbstractC(blah: Blah(), kaa: BB())
     }
 
-    var grandParentVar: GrandParentVar {
+    override var grandParentVar: GrandParentVar {
         return GrandParentVar(child: self)
     }
 
-    func parentMethod(index: Int) -> String {
+    override func parentMethod(index: Int) -> String {
         return "concrete"
     }
 }
 
 class ConcreteClass2: GrandParentAbstractClass {
-    var grandParentVar: GrandParentVar {
+    override var grandParentVar: GrandParentVar {
         return GrandParentVar(child: self)
     }
 }

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/GenericSuperConcreteSubclass.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/GenericSuperConcreteSubclass.swift
@@ -1,0 +1,10 @@
+class ConcreteClassGenericType: AProtocol, GenericBaseClass<String> {
+
+    override var genericTypeVar: String {
+        return "var"
+    }
+
+    override func returnGenericType() -> String {
+        return ""
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/InnerConcreteSubclass.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/InnerConcreteSubclass.swift
@@ -5,7 +5,7 @@ class AnOutterClass {
 
     func someMethod(index: Int) -> String {
         class ConcreteClass2: GrandParentAbstractClass {
-            var grandParentVar: GrandParentVar {
+            override var grandParentVar: GrandParentVar {
                 return GrandParentVar(child: self)
             }
         }

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/SubclassUsageFilterTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/SubclassUsageFilterTaskTests.swift
@@ -17,20 +17,11 @@
 import XCTest
 @testable import AbstractClassValidatorFramework
 
-class ExpressionCallUsageFilterTaskTests: BaseFrameworkTests {
-
-    private var abstractClassDefinition: AbstractClassDefinition!
-
-    override func setUp() {
-        super.setUp()
-
-        let abstractVarDefinition = VarDefinition(name: "abVar", returnType: "Var", isAbstract: true, isOverride: false)
-        abstractClassDefinition = AbstractClassDefinition(name: "SomeAbstractC", vars: [abstractVarDefinition], methods: [], inheritedTypes: [])
-    }
+class SubclassUsageFilterTaskTests: BaseFrameworkTests {
 
     func test_execute_noExclusion_noAbstractClass_verifyResult() {
         let url = fixtureUrl(for: "NoAbstractClass.swift")
-        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [])
+        let task = SubclassUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [])
 
         let result = try! task.execute()
 
@@ -43,8 +34,8 @@ class ExpressionCallUsageFilterTaskTests: BaseFrameworkTests {
     }
 
     func test_execute_suffixExclusion_hasAbstractClass_verifyResult() {
-        let url = fixtureUrl(for: "ViolateInstantiation.swift")
-        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: ["Instantiation"], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
+        let url = fixtureUrl(for: "ConcreteSubclass.swift")
+        let task = SubclassUsageFilterTask(url: url, exclusionSuffixes: ["Subclass"], exclusionPaths: [], abstractClassDefinitions: [AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [], inheritedTypes: [])])
 
         let result = try! task.execute()
 
@@ -57,8 +48,8 @@ class ExpressionCallUsageFilterTaskTests: BaseFrameworkTests {
     }
 
     func test_execute_pathExclusion_hasAbstractClass_verifyResult() {
-        let url = fixtureUrl(for: "ViolateInstantiation.swift")
-        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: ["Fixtures/"], abstractClassDefinitions: [abstractClassDefinition])
+        let url = fixtureUrl(for: "ConcreteSubclass.swift")
+        let task = SubclassUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: ["Fixtures/"], abstractClassDefinitions: [AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [], inheritedTypes: [])])
 
         let result = try! task.execute()
 
@@ -70,9 +61,24 @@ class ExpressionCallUsageFilterTaskTests: BaseFrameworkTests {
         }
     }
 
-    func test_execute_noExclusion_hasAbstractSubclass_verifyResult() {
-        let url = fixtureUrl(for: "ViolateInstantiation.swift")
-        let task = ExpressionCallUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [abstractClassDefinition])
+    func test_execute_noExclusion_simpleSubclass_verifyResult() {
+        let url = fixtureUrl(for: "ConcreteSubclass.swift")
+        let task = SubclassUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [AbstractClassDefinition(name: "ParentAbstractClass", vars: [], methods: [], inheritedTypes: [])])
+
+        let result = try! task.execute()
+
+        switch result {
+        case .shouldProcess(let processUrl, let content):
+            XCTAssertEqual(processUrl, url)
+            XCTAssertEqual(content, try! String(contentsOf: url))
+        case .skip:
+            XCTFail()
+        }
+    }
+
+    func test_execute_noExclusion_genericSubclass_verifyResult() {
+        let url = fixtureUrl(for: "GenericSuperConcreteSubclass.swift")
+        let task = SubclassUsageFilterTask(url: url, exclusionSuffixes: [], exclusionPaths: [], abstractClassDefinitions: [AbstractClassDefinition(name: "GenericBaseClass", vars: [], methods: [], inheritedTypes: [])])
 
         let result = try! task.execute()
 


### PR DESCRIPTION
…asses

Fixed `SubclassUsageFilterTask` to include subclasses of generic super abstract classes. Also fixed protocol conformance being in front of behind super class inheritance in subclass declarations.

Fixed `ConcreteSubclassProducerTask` and `DeclarationProducerTask` to use `inheritedTypeNames` since `inheritedTypes` includes the full generic types.

Added `SubclassUsageFilterTaskTests`.