### PR TITLE
Update implementation validation to support generics

### DIFF
--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassValidationTaskTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ConcreteSubclassValidationTaskTests.swift
@@ -114,8 +114,8 @@ class ConcreteSubclassValidationTaskTests: BaseFrameworkTests {
         switch result {
         case .failureWithReason(let reason):
             XCTAssertTrue(reason.contains(aggregatedParentClass.value.name))
-            XCTAssertTrue(reason.contains("(pV2: PV2)"))
-            XCTAssertTrue(reason.contains("(pV1: PV1)"))
+            XCTAssertTrue(reason.contains("pV2"))
+            XCTAssertTrue(reason.contains("pV1"))
             XCTAssertTrue(reason.contains(URL(fileURLWithPath: #file).path))
         default:
             XCTFail()
@@ -138,7 +138,7 @@ class ConcreteSubclassValidationTaskTests: BaseFrameworkTests {
         switch result {
         case .failureWithReason(let reason):
             XCTAssertTrue(reason.contains(aggregatedChildClass.value.name))
-            XCTAssertTrue(reason.contains("(cV: CV)"))
+            XCTAssertTrue(reason.contains("cV"))
             XCTAssertTrue(reason.contains(URL(fileURLWithPath: #file).path))
         default:
             XCTFail()
@@ -159,8 +159,8 @@ class ConcreteSubclassValidationTaskTests: BaseFrameworkTests {
         switch result {
         case .failureWithReason(let reason):
             XCTAssertTrue(reason.contains(aggregatedParentClass.value.name))
-            XCTAssertTrue(reason.contains("(gM1() -> GM1)"))
-            XCTAssertTrue(reason.contains("(gM2(_: GMP1, arg2: GMP2) -> GM2)"))
+            XCTAssertTrue(reason.contains("gM1"))
+            XCTAssertTrue(reason.contains("gM2(_:arg2:)"))
             XCTAssertTrue(reason.contains(URL(fileURLWithPath: #file).path))
         default:
             XCTFail()
@@ -183,7 +183,7 @@ class ConcreteSubclassValidationTaskTests: BaseFrameworkTests {
         switch result {
         case .failureWithReason(let reason):
             XCTAssertTrue(reason.contains(aggregatedChildClass.value.name))
-            XCTAssertTrue(reason.contains("(cM(arg: CMP) -> CM)"))
+            XCTAssertTrue(reason.contains("cM(arg:)"))
             XCTAssertTrue(reason.contains(URL(fileURLWithPath: #file).path))
         default:
             XCTFail()

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/GenericSuperclass/ChildConcrete.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/GenericSuperclass/ChildConcrete.swift
@@ -1,0 +1,14 @@
+class ChildConcrete: BlahProtocol, ChildAbstract<String, Int> {
+
+    override var gpAbstractVar: GPVar {
+        return GPVar()
+    }
+
+    override func pAbstractMethod(arg1: Int) -> Int {
+        return PMethod(arg: arg1)
+    }
+
+    override func cAbstractMethod(_ a: String, b: String) -> String {
+        return CMethod(a: a, b: b)
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/GenericSuperclass/GrandParentAbstract.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/GenericSuperclass/GrandParentAbstract.swift
@@ -1,0 +1,19 @@
+class GrandParentAbstract: AbstractClass {
+    var gpAbstractVar: GPVar {
+        abstractMethod()
+    }
+
+    let gpLet = "haha"
+
+    var gpConcreteVar: Int {
+        return 21
+    }
+
+    func gpConcreteMethod() -> String {
+        return "blah"
+    }
+
+    func gpAbstractMethod() -> GPMethod {
+        abstractMethod()
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/GenericSuperclass/ParentAbstractChildAbstractNested.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/Fixtures/Integration/Invalid/GenericSuperclass/ParentAbstractChildAbstractNested.swift
@@ -1,0 +1,32 @@
+class ParentAbstract<T>: GrandParentAbstract {
+
+    var pConcreteVar: PVar {
+        return PVar()
+    }
+
+    func pConcreteMethod() -> Blah {
+        return Blah()
+    }
+
+    func pAbstractMethod(arg1: T) -> T {
+        abstractMethod()
+    }
+
+    class ChildAbstract<T, P>: ParentAbstract<P> {
+        var cAbstractVar: CVar {
+            abstractMethod()
+        }
+
+        var cConcreteVar: ChildConcrete {
+            return ChildConcrete()
+        }
+
+        func cAbstractMethod(_ a: T, b: T) -> T {
+            abstractMethod()
+        }
+
+        func cConcreteMethod() -> Int {
+            return 12
+        }
+    }
+}

--- a/Validator/Tests/AbstractClassValidatorFrameworkTests/ValidatorTests.swift
+++ b/Validator/Tests/AbstractClassValidatorFrameworkTests/ValidatorTests.swift
@@ -61,7 +61,21 @@ class ValidatorTests: BaseFrameworkTests {
             XCTFail()
         } catch GenericError.withMessage(let message) {
             XCTAssertTrue(message.contains("ChildConcrete"))
-            XCTAssertTrue(message.contains("(cAbstractVar: CVar)"))
+            XCTAssertTrue(message.contains("cAbstractVar"))
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func test_validate_noExclusions_withGenericSuperclassImplementationViolations_verifyError() {
+        let sourceRoot = fixtureUrl(for: "/Integration/Invalid/GenericSuperclass/")
+
+        do {
+            try Validator().validate(from: [sourceRoot.path], excludingFilesEndingWith: [], excludingFilesWithPaths: [], shouldCollectParsingInfo: false, timeout: 10, concurrencyLimit: nil)
+            XCTFail()
+        } catch GenericError.withMessage(let message) {
+            XCTAssertTrue(message.contains("ChildConcrete"))
+            XCTAssertTrue(message.contains("cAbstractVar"))
         } catch {
             XCTFail()
         }


### PR DESCRIPTION
Since property return types, method parameter types and method return types can be based on generic types, implementation validation cannot directly check them. Instead check for `isOverride` attribute and property/method names.