### PR TITLE
Update Validator dependency to a specific version of swift-common

### DIFF
--- a/Validator/Package.swift
+++ b/Validator/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.20.0"),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.7.1")),
-        .package(url: "https://github.com/uber/swift-common.git", .branch("master")),
+        .package(url: "https://github.com/uber/swift-common.git", .exact("0.1.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
We want to this in order to enable upgrade of the swift-common framework
to Swift 5.1 without breaking SwiftAbstractClass.

Fixes issue #35 .